### PR TITLE
fix(plugin-id): replace hardcoded entity probes with list probes for …

### DIFF
--- a/ui/src/views/CompanyEditView.vue
+++ b/ui/src/views/CompanyEditView.vue
@@ -223,7 +223,11 @@ onMounted(async () => {
       { title: t('company.title'), to: '/id/company' },
       { title: t('company.new') },
     ])
-    const check = await api.get('rest/service/id/company/Ligoj')
+    // Check if API is available. Use a list probe (rows=1) so the check doesn't
+    // depend on a specific hardcoded entity that may or may not exist in the
+    // real LDAP backend. The list endpoint returns 200 with an empty array when
+    // nothing matches, and `code` is only set on real API errors.
+    const check = await api.get('rest/service/id/company?rows=1&page=1')
     if (!check || check.code) {
       demoMode.value = true
       errorStore.clear()

--- a/ui/src/views/GroupEditView.vue
+++ b/ui/src/views/GroupEditView.vue
@@ -168,7 +168,11 @@ onMounted(async () => {
       { title: t('group.title'), to: '/id/group' },
       { title: t('group.new') },
     ])
-    const check = await api.get('rest/service/id/group/Engineering')
+    // Check if API is available. Use a list probe (rows=1) so the check doesn't
+    // depend on a specific hardcoded entity that may or may not exist in the
+    // real LDAP backend. The list endpoint returns 200 with an empty array when
+    // nothing matches, and `code` is only set on real API errors.
+    const check = await api.get('rest/service/id/group?rows=1&page=1')
     if (!check || check.code) {
       demoMode.value = true
       errorStore.clear()

--- a/ui/src/views/UserEditView.vue
+++ b/ui/src/views/UserEditView.vue
@@ -400,8 +400,11 @@ onMounted(async () => {
       { title: t('user.title'), to: '/id/user' },
       { title: t('user.new') },
     ])
-    // Check if API is available
-    const check = await api.get('rest/service/id/user/admin')
+    // Check if API is available. Use a list probe (rows=1) so the check doesn't
+    // depend on a specific hardcoded entity that may or may not exist in the
+    // real LDAP backend. The list endpoint returns 200 with an empty array when
+    // nothing matches, and `code` is only set on real API errors.
+    const check = await api.get('rest/service/id/user?rows=1&page=1')
     if (!check || check.code) {
       demoMode.value = true
       errorStore.clear()


### PR DESCRIPTION
Fixes a bug where the "Mode démo" banner appeared incorrectly on the
/new pages (user, company, group) whenever a real IAM provider was
configured.

## Cause

Each EditView did an API probe on a specific hardcoded entity to
detect if the API was available:

- UserEditView.vue → rest/service/id/user/admin
- CompanyEditView.vue → rest/service/id/company/Ligoj
- GroupEditView.vue → rest/service/id/group/Engineering

These entities exist in the iam:empty fallback (which returns fake
data for any id), but don't exist in real LDAP backends. So once
plugin-iam-node + plugin-id-ldap were activated, the probe returned
`code != 0` (entity not found), which set demoMode to true and
displayed the banner — even though the API was working fine.

## Fix

Replace the entity probe with a list endpoint (rows=1, page=1) that
returns 200 with an empty data array when nothing matches, and only
sets `code` on real API errors:

- rest/service/id/user?rows=1&page=1
- rest/service/id/company?rows=1&page=1
- rest/service/id/group?rows=1&page=1

The demoMode flag is now only triggered when the API is genuinely
unavailable, not when the previously-hardcoded fixture entity
happens to not exist.

## Test

Validated visually with LDAP active (plugin-iam-node + plugin-id-ldap
+ 1000 bench users):

- /id/user/new, /id/company/new, /id/group/new → no demo banner
- /id/user/cli1, /id/company/department1, /id/group/<existing> →
  no regression on edit pages
- Lint OK, build OK

Per Fabrice's review in the 18 mai 13:30 meeting.