### PR TITLE
feat(plugin-id): show Groups field on user creation with preloaded dropdown

### DIFF
--- a/ui/src/views/UserEditView.vue
+++ b/ui/src/views/UserEditView.vue
@@ -58,8 +58,8 @@
                v-model holds an array of group **names** (strings),
                matching the payload contract of rest/service/id/user. -->
           <v-autocomplete
-            v-if="isEdit"
             v-model="groups"
+            v-model:menu="groupMenu"
             :items="groupResults"
             :loading="groupLoading"
             :search="groupSearchQuery"
@@ -191,6 +191,7 @@ let companyDebounce = null
 const groupSearchQuery = ref('')
 const groupResults = ref([])
 const groupLoading = ref(false)
+const groupMenu = ref(false)
 let groupDebounce = null
 
 const isEdit = computed(() => !!route.params.id)
@@ -284,6 +285,24 @@ function onGroupSearch(query) {
 function onGroupModelUpdate() {
   groupSearchQuery.value = ''
   groupResults.value = []
+}
+
+/** Preload the first page of groups so the dropdown can be opened
+ *  with content already visible on mount (used on /new where the user
+ *  has no pre-selected groups). The list endpoint returns 200 with an
+ *  empty array when no IAM is configured, so this is safe to call. */
+async function preloadGroups() {
+  groupLoading.value = true
+  try {
+    const url = 'rest/service/id/group?rows=20&page=1&sidx=name&sord=asc'
+    const resp = await api.get(url)
+    groupResults.value = Array.isArray(resp) ? resp : (Array.isArray(resp?.data) ? resp.data : [])
+  } catch (err) {
+    console.error('Group preload failed:', err)
+    groupResults.value = []
+  } finally {
+    groupLoading.value = false
+  }
 }
 
 async function searchGroups(query) {
@@ -406,6 +425,11 @@ onMounted(async () => {
       demoMode.value = true
       errorStore.clear()
     }
+    // Preload group list and open the dropdown so the available groups
+    // are visible on mount (per Fabrice's UX feedback). Only on /new
+    // since /edit already shows the user's existing groups as chips.
+    await preloadGroups()
+    groupMenu.value = true
   }
   initGuard()
 })
@@ -427,9 +451,8 @@ async function save() {
     company: form.value.company,
     mail: form.value.mail,
     // groups is an array of names (strings). Defensive `.map(g => g.name || g)`
-    // in case any legacy object slipped through. Only sent on edit since the
-    // groups field is hidden on New User for this PR.
-    ...(isEdit.value ? { groups: groups.value.map(g => g.name || g) } : {}),
+    // in case any legacy object slipped through.
+    groups: groups.value.map(g => g.name || g),
   }
 
   if (isEdit.value) {


### PR DESCRIPTION
Make the Groups multi-select autosuggest visible on user creation, not
only on edit (per Fabrice's review of 18 mai 13:30).

## Main change
Remove `v-if="isEdit"` from the Groups v-autocomplete block so the field
is shown on both /id/user/new and /id/user/:id. The save() payload is
updated to send the `groups` array in both create and edit modes.

## Bonus UX
While touching the Groups field, also preload the first 20 groups via
`rest/service/id/group?rows=20` at mount and open the dropdown so the
user can browse without having to type. This addresses an adjacent
review point ("le dropdown des groupes devrait afficher une liste
filtrée même si l'utilisateur n'a pas saisi de caractères").

## Tested
- /id/user/new : Groupes field visible, dropdown preloaded with 20 LDAP
  groups, autosuggest filters on keystroke, chips selectable
- /id/user/cli1 (edit) : no regression