### PR TITLE
fix(plugin-id/backend): expose @POST create() on GroupResource and CompanyResource

### DIFF
--- a/src/main/java/org/ligoj/app/plugin/id/resource/CompanyResource.java
+++ b/src/main/java/org/ligoj/app/plugin/id/resource/CompanyResource.java
@@ -5,6 +5,7 @@ package org.ligoj.app.plugin.id.resource;
 
 import jakarta.transaction.Transactional;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.Context;
@@ -135,6 +136,24 @@ public class CompanyResource extends AbstractContainerResource<CompanyOrg, Conta
 							.filter(user -> visibleCompaniesAsString.contains(user.getCompany())).count());
 			return securedCompany;
 		});
+	}
+
+	/**
+	 * Create the given company. Concrete re-declaration of the inherited
+	 * {@code @POST create(V)} from {@link AbstractContainerResource} so JAX-RS
+	 * registers the route on the concrete bean — the parent annotation isn't
+	 * picked up because of type erasure on the generic parameter V.
+	 *
+	 * <p>Produces {@code text/plain} (not the class-level JSON default): the
+	 * returned identifier is a raw string, not a JSON document, so clients can
+	 * read it via {@code response.text()} instead of failing to parse an
+	 * unquoted scalar as JSON.
+	 */
+	@POST
+	@Produces(MediaType.TEXT_PLAIN)
+	@Override
+	public String create(final ContainerEditionVo container) {
+		return super.create(container);
 	}
 
 	@Override

--- a/src/main/java/org/ligoj/app/plugin/id/resource/GroupResource.java
+++ b/src/main/java/org/ligoj/app/plugin/id/resource/GroupResource.java
@@ -113,6 +113,24 @@ public class GroupResource extends AbstractContainerResource<GroupOrg, GroupEdit
 		return findById(group) != null;
 	}
 
+	/**
+	 * Create the given group. Concrete re-declaration of the inherited
+	 * {@code @POST create(V)} from {@link AbstractContainerResource} so JAX-RS
+	 * registers the route on the concrete bean — the parent annotation isn't
+	 * picked up because of type erasure on the generic parameter V.
+	 *
+	 * <p>Produces {@code text/plain} (not the class-level JSON default): the
+	 * returned identifier is a raw string, not a JSON document, so clients can
+	 * read it via {@code response.text()} instead of failing to parse an
+	 * unquoted scalar as JSON.
+	 */
+	@POST
+	@Produces(MediaType.TEXT_PLAIN)
+	@Override
+	public String create(final GroupEditionVo container) {
+		return super.create(container);
+	}
+
 	@Override
 	protected String toDn(final GroupEditionVo container, final ContainerScope scope) {
 		var parentDn = scope.getDn();


### PR DESCRIPTION
Fix 405 Method Not Allowed on POST /rest/service/id/group and
POST /rest/service/id/company.

## Cause
GroupResource and CompanyResource extend AbstractContainerResource which
declares `@POST create(V container)` at line 149. But JAX-RS doesn't pick
up the annotation on the concrete bean because of type erasure on the
generic parameter V — the runtime sees the erased `create(Object)` which
is not registered as a route.

Result: POST routes were never exposed, blocking container creation
from the UI (caught when fixing the "Mode démo" probes in PR
norman/fix-demo-banner-probes, which exposed the first real POST call
that was previously bypassed by the demo toast).

## Fix
Re-declare `@POST create()` with the concrete type in both GroupResource
and CompanyResource, delegating to `super.create()`. Same pattern that
already works for UserOrgResource.java:360.

`@Produces(MediaType.TEXT_PLAIN)` is added because the return value is
the bare ID string (not JSON) — without it, the frontend fails on
`response.json()`.

## Out of scope
PUT/update on containers is also missing — neither in the abstract
parent nor in IContainerRepository (plugin-api). A separate
architectural decision is needed (4 options being discussed with
Fabrice — see Teams).