### PR TITLE
fix(plugin-id/ui): map scope name to Integer ID before save (Company + Group)

### DIFF
--- a/ui/src/views/CompanyEditView.vue
+++ b/ui/src/views/CompanyEditView.vue
@@ -242,8 +242,17 @@ async function save() {
     return
   }
 
+  // Resolve the scope ID from its name. The backend expects an Integer
+  // ID (container scope), not the string name. scopeAll is preloaded at
+  // mount() from rest/service/id/container-scope/COMPANY.
+  const scopeEntry = scopeAll.value.find(s => s.name === form.value.scope)
+  if (!scopeEntry) {
+    errorStore.push({ message: `Unknown scope: ${form.value.scope}`, status: 0 })
+    return
+  }
+
   saving.value = true
-  const payload = { name: form.value.name, scope: form.value.scope }
+  const payload = { name: form.value.name, scope: scopeEntry.id }
 
   if (isEdit.value) {
     await api.put('rest/service/id/company', payload)

--- a/ui/src/views/GroupEditView.vue
+++ b/ui/src/views/GroupEditView.vue
@@ -75,6 +75,9 @@ const confirmDelete = ref(false)
 const demoMode = ref(false)
 const availableGroups = ref([])
 const availableScopes = ref([])
+// Full scope objects ({id, name, ...}) — used at save() to resolve the
+// Integer ID expected by the backend from the name held in form.value.scope.
+const scopeAll = ref([])
 const scopesLoading = ref(false)
 
 const isEdit = computed(() => route.params.id && route.params.id !== 'new')
@@ -113,11 +116,14 @@ async function loadGroupScopes() {
     const data = await api.get('rest/service/id/container-scope/group')
     const rows = Array.isArray(data) ? data : (Array.isArray(data?.data) ? data.data : null)
     if (rows) {
+      scopeAll.value = rows
       availableScopes.value = rows.map((s) => s.name).filter(Boolean)
     } else {
+      scopeAll.value = []
       availableScopes.value = ['Group', 'Department', 'Team', 'Project']
     }
   } catch {
+    scopeAll.value = []
     availableScopes.value = ['Group', 'Department', 'Team', 'Project']
   } finally {
     scopesLoading.value = false
@@ -186,8 +192,17 @@ async function save() {
     return
   }
 
+  // Resolve the scope ID from its name. The backend expects an Integer
+  // ID (container scope), not the string name. scopeAll is preloaded at
+  // mount() from rest/service/id/container-scope/group.
+  const scopeEntry = scopeAll.value.find(s => s.name === form.value.scope)
+  if (!scopeEntry) {
+    errorStore.push({ message: `Unknown scope: ${form.value.scope}`, status: 0 })
+    return
+  }
+
   saving.value = true
-  const payload = { name: form.value.name, scope: form.value.scope, parent: form.value.parent || null }
+  const payload = { name: form.value.name, scope: scopeEntry.id, parent: form.value.parent || null }
 
   if (isEdit.value) {
     await api.put('rest/service/id/group', payload)


### PR DESCRIPTION
After fixing the @POST 405 (PR norman/fix-container-resource-post),
POST /group returned 400 with {"errors":{"scope":[{"rule":"Integer"}]}}.

## Cause
The backend expects `scope` as the container scope's Integer ID, but the
frontend was sending the string name (e.g. "Internal", "Functional")
because the v-autocomplete uses `item-value="name"` for display purposes.

## Fix
At save() time, resolve the scope ID from the preloaded `scopeAll` list
(loaded at mount via GET /container-scope/<TYPE>). This keeps the
v-model as a clean string for display while sending the correct integer
ID at the API boundary. A guard rejects unknown scope names with a toast
rather than sending an invalid payload.

## Files
- CompanyEditView.vue (save())
- GroupEditView.vue (save())

UserEditView.vue is not affected — User.company and User.groups accept
string names in the backend payload.

## Tested
/id/company/new : created "TestCo" with scope "Internal" → save OK,
appears in list, redirect OK.