### PR TITLE
fix(plugin-id/ui): keep dropdown list intact after value selection

### DIFF
--- a/ui/src/views/CompanyEditView.vue
+++ b/ui/src/views/CompanyEditView.vue
@@ -167,7 +167,11 @@ function onScopeSearch(query) {
 }
 
 function filterScopes(query) {
-  if (!query) {
+  // After picking a scope, Vuetify echoes the selected name back through
+  // @update:search — if we treat that as a filter query we narrow the list
+  // to just the picked item and the user can't switch to another scope on
+  // re-open. Treat it as "show everything" instead.
+  if (!query || query === form.value.scope) {
     scopeResults.value = scopeAll.value
     return
   }


### PR DESCRIPTION
Fix Vuetify v-autocomplete dropdown filter that was incorrectly
reducing the list to a single item after selection on edit views,
making it impossible to change the value later.

## Cause
When the user picks a value, Vuetify re-emits the selected value's
name through `@update:search`. Our local filter (used because the
scope dataset is small and preloaded) interpreted this as a new search
query and reduced the list to just the selected item.

## Fix
Ignore the @update:search event if the query matches the currently-
selected value. Tiny patch on filterScopes().

## Files
- CompanyEditView.vue (filterScopes)