### PR TITLE
feat(plugin-id/ui): highlight entity name in delete confirmation dialogs

### DIFF
--- a/ui/src/i18n/en.js
+++ b/ui/src/i18n/en.js
@@ -1,0 +1,11 @@
+// Plugin-local translations merged into the host i18n store at install
+// time. Keep keys flat (dot-separated) to match the host's existing
+// convention.
+export default {
+  'user.deleteConfirmBefore': 'Are you sure you want to delete ',
+  'user.deleteConfirmAfter': '?',
+  'group.deleteConfirmBefore': 'Are you sure you want to delete ',
+  'group.deleteConfirmAfter': '?',
+  'company.deleteConfirmBefore': 'Are you sure you want to delete ',
+  'company.deleteConfirmAfter': '?',
+}

--- a/ui/src/i18n/fr.js
+++ b/ui/src/i18n/fr.js
@@ -1,0 +1,11 @@
+// Plugin-local translations merged into the host i18n store at install
+// time. Keep keys flat (dot-separated) to match the host's existing
+// convention.
+export default {
+  'user.deleteConfirmBefore': 'Êtes-vous certain de supprimer ',
+  'user.deleteConfirmAfter': ' ?',
+  'group.deleteConfirmBefore': 'Êtes-vous certain de supprimer ',
+  'group.deleteConfirmAfter': ' ?',
+  'company.deleteConfirmBefore': 'Êtes-vous certain de supprimer ',
+  'company.deleteConfirmAfter': ' ?',
+}

--- a/ui/src/index.js
+++ b/ui/src/index.js
@@ -33,6 +33,7 @@ if (typeof document !== 'undefined') {
  * Shared host surface (stores, composables) is imported from `@ligoj/host`,
  * kept external at build so plugin and host share the same instances.
  */
+import { useI18nStore } from '@ligoj/host'
 import IdPlugin from './IdPlugin.vue'
 import UserListView from './views/UserListView.vue'
 import UserEditView from './views/UserEditView.vue'
@@ -43,6 +44,8 @@ import CompanyEditView from './views/CompanyEditView.vue'
 import DelegateListView from './views/DelegateListView.vue'
 import DelegateEditView from './views/DelegateEditView.vue'
 import ContainerScopeView from './views/ContainerScopeView.vue'
+import enMessages from './i18n/en.js'
+import frMessages from './i18n/fr.js'
 import service from './service.js'
 
 const features = {
@@ -76,6 +79,10 @@ export default {
     for (const route of routes) {
       router.addRoute(route)
     }
+    // Register plugin-local translations into the host i18n store
+    const i18n = useI18nStore()
+    i18n.merge(enMessages, 'en')
+    i18n.merge(frMessages, 'fr')
   },
   feature(action, ...args) {
     const fn = features[action]

--- a/ui/src/views/CompanyEditView.vue
+++ b/ui/src/views/CompanyEditView.vue
@@ -60,7 +60,7 @@
       <v-card>
         <v-card-title>{{ t('company.deleteTitle') }}</v-card-title>
         <v-card-text>
-          {{ t('company.deleteConfirm', { name: form.name }) }}
+          {{ t('company.deleteConfirmBefore') }}<strong class="text-error">{{ form.name }}</strong>{{ t('company.deleteConfirmAfter') }}
         </v-card-text>
         <v-card-actions>
           <v-spacer />

--- a/ui/src/views/CompanyListView.vue
+++ b/ui/src/views/CompanyListView.vue
@@ -50,7 +50,7 @@
       <v-card>
         <v-card-title>{{ t('company.deleteTitle') }}</v-card-title>
         <v-card-text>
-          {{ t('company.deleteConfirm', { name: deleteTarget?.name }) }}
+          {{ t('company.deleteConfirmBefore') }}<strong class="text-error">{{ deleteTarget?.name }}</strong>{{ t('company.deleteConfirmAfter') }}
         </v-card-text>
         <v-card-actions>
           <v-spacer />

--- a/ui/src/views/GroupEditView.vue
+++ b/ui/src/views/GroupEditView.vue
@@ -30,7 +30,7 @@
       <v-card>
         <v-card-title>{{ t('group.deleteTitle') }}</v-card-title>
         <v-card-text>
-          {{ t('group.deleteConfirm', { name: form.name }) }}
+          {{ t('group.deleteConfirmBefore') }}<strong class="text-error">{{ form.name }}</strong>{{ t('group.deleteConfirmAfter') }}
         </v-card-text>
         <v-card-actions>
           <v-spacer />

--- a/ui/src/views/GroupListView.vue
+++ b/ui/src/views/GroupListView.vue
@@ -50,7 +50,7 @@
       <v-card>
         <v-card-title>{{ t('group.deleteTitle') }}</v-card-title>
         <v-card-text>
-          {{ t('group.deleteConfirm', { name: deleteTarget?.name }) }}
+          {{ t('group.deleteConfirmBefore') }}<strong class="text-error">{{ deleteTarget?.name }}</strong>{{ t('group.deleteConfirmAfter') }}
         </v-card-text>
         <v-card-actions>
           <v-spacer />

--- a/ui/src/views/UserEditView.vue
+++ b/ui/src/views/UserEditView.vue
@@ -119,7 +119,7 @@
       <v-card>
         <v-card-title>{{ t('user.deleteTitle') }}</v-card-title>
         <v-card-text>
-          {{ t('user.deleteConfirm', { id: form.id }) }}
+          {{ t('user.deleteConfirmBefore') }}<strong class="text-error">{{ form.id }}</strong>{{ t('user.deleteConfirmAfter') }}
         </v-card-text>
         <v-card-actions>
           <v-spacer />

--- a/ui/src/views/UserListView.vue
+++ b/ui/src/views/UserListView.vue
@@ -62,7 +62,7 @@
       <v-card>
         <v-card-title>{{ t('user.deleteTitle') }}</v-card-title>
         <v-card-text>
-          {{ t('user.deleteConfirm', { id: deleteTarget?.id }) }}
+          {{ t('user.deleteConfirmBefore') }}<strong class="text-error">{{ deleteTarget?.id }}</strong>{{ t('user.deleteConfirmAfter') }}
         </v-card-text>
         <v-card-actions>
           <v-spacer />


### PR DESCRIPTION
Highlight entity names (bold + error color) in the "Confirm delete"
dialogs across plugin-id, so users can quickly verify what they're
about to delete (per Fabrice's review of 18 mai 13:30).

## Scope
Covers all 6 confirm-delete dialogs in plugin-id:
- 3 EditViews : User/Group/CompanyEditView (Delete button in form)
- 3 ListViews : User/Group/CompanyListView (delete action on row)

Bulk-delete dialogs are not affected (they show a count, not a name).

## Implementation
Split the i18n message into two halves (Before/After the name) and
render the entity name as `<strong class="text-error">` in the
template — keeps i18n strings free of HTML markup.

## Plugin-local i18n
New pattern: the plugin now ships its own translations in
`ui/src/i18n/{en,fr}.js`, merged into the host i18n store via
`useI18nStore().merge(messages, locale)` in the plugin's `install()`
function. This avoids cross-repo coupling (no host PR needed for
plugin-local i18n).

The legacy `*.deleteConfirm` keys are kept untouched in the host
i18n in case other consumers still reference them.

## Files
9 files, +35/-6 :
- ui/src/i18n/en.js (new — 6 keys)
- ui/src/i18n/fr.js (new — 6 keys)
- ui/src/index.js (import + merge in install())
- 6 views (3 Edit + 3 List)

## Tested
Visual validation FR + EN on the 6 dialogs : name appears in red bold,
no regression on other dialogs.