### PR TITLE
fix(plugin-id/ui): keep user list group chips on a single line

### DIFF
--- a/ui/src/views/UserListView.vue
+++ b/ui/src/views/UserListView.vue
@@ -39,10 +39,12 @@
         {{ item.mails?.[0] || '' }}
       </template>
       <template #item.groups="{ item }">
-        <v-chip v-for="g in (item.groups || []).slice(0, 3)" :key="g.name || g" size="small" class="mr-1">{{ g.name || g }}</v-chip>
-        <span v-if="(item.groups || []).length > 3" class="text-caption text-medium-emphasis">
-          +{{ item.groups.length - 3 }}
-        </span>
+        <div class="groups-cell">
+          <v-chip v-for="g in (item.groups || []).slice(0, 3)" :key="g.name || g" size="small" class="mr-1">{{ g.name || g }}</v-chip>
+          <span v-if="(item.groups || []).length > 3" class="text-caption text-medium-emphasis">
+            +{{ item.groups.length - 3 }}
+          </span>
+        </div>
       </template>
       <template #item.locked="{ item }">
         <v-icon v-if="item.locked" color="error" size="small">mdi-lock</v-icon>
@@ -195,5 +197,16 @@ onMounted(() => {
   min-width: 200px;
   max-width: 300px;
   flex: 1 1 200px;
+}
+
+/* Keep the groups column on a single line so rows stay vertically
+   aligned when a user has many groups. Chips overflow horizontally
+   instead of wrapping. */
+.groups-cell {
+  display: flex;
+  align-items: center;
+  flex-wrap: nowrap;
+  overflow: hidden;
+  white-space: nowrap;
 }
 </style>


### PR DESCRIPTION
Keep the group chips on a single line in the user list, so vertical
alignment stays consistent across rows regardless of how many groups
each user belongs to.

## Fix
Wrap the `#item.groups` slot of LigojDataTableServer in a
`<div class="groups-cell">` with scoped CSS:

  display: flex;
  align-items: center;
  flex-wrap: nowrap;
  overflow: hidden;
  white-space: nowrap;

Chips that exceed the column width are now hidden on the right by
overflow:hidden instead of wrapping onto a 2nd line.

## Files
1 file, +17/-4 — UserListView.vue.

## Note on validation
Local dev LDAP has only one group and no multi-group users, so the
original wrap couldn't be reproduced directly. Validation was done by
manually assigning Sample Group to cli10 and resizing the Chrome
window to force truncation (visible: chip "Sample Grou" cut off
horizontally instead of wrapping). The canonical CSS fix is low-risk
for this single-cell concern — to revalidate on a richer environment
if needed.