### PR TITLE
fix(plugin-id/ui): harmonize actions column layout across Identity ListViews

### DIFF
--- a/ui/src/views/CompanyListView.vue
+++ b/ui/src/views/CompanyListView.vue
@@ -107,7 +107,7 @@ const headers = computed(() => [
   { title: t('group.scope'), key: 'scope', sortable: false },
   { title: t('group.members'), key: 'count', sortable: false, width: '100px' },
   { title: t('group.locked'), key: 'locked', sortable: false, width: '80px' },
-  { title: '', key: 'actions', sortable: false, width: '100px', align: 'end' },
+  { title: '', key: 'actions', sortable: false, width: '120px', align: 'center' },
 ])
 
 function loadData(options) {

--- a/ui/src/views/GroupListView.vue
+++ b/ui/src/views/GroupListView.vue
@@ -109,7 +109,7 @@ const headers = computed(() => [
   { title: t('group.scope'), key: 'scope', sortable: false },
   { title: t('group.members'), key: 'count', sortable: false, width: '100px' },
   { title: t('group.locked'), key: 'locked', sortable: false, width: '80px' },
-  { title: '', key: 'actions', sortable: false, width: '120px', align: 'end' },
+  { title: '', key: 'actions', sortable: false, width: '120px', align: 'center' },
 ])
 
 function loadData(options) {

--- a/ui/src/views/UserListView.vue
+++ b/ui/src/views/UserListView.vue
@@ -128,7 +128,7 @@ const headers = computed(() => [
   { title: t('user.email'), key: 'mails', sortable: false },
   { title: t('user.groups'), key: 'groups', sortable: false },
   { title: t('common.status'), key: 'locked', sortable: false, width: '80px' },
-  { title: '', key: 'actions', sortable: false, width: '100px', align: 'end' },
+  { title: '', key: 'actions', sortable: false, width: '120px', align: 'center' },
 ])
 
 function loadData(options) {


### PR DESCRIPTION
Harmonize the actions column on the three Identity ListViews
(User / Group / Company).

## Finding
The review item mentioned the user list, but investigation showed
UserListView and CompanyListView were already aligned at width 100px —
GroupListView was the outlier at 120px.

However, 100px combined with `align: 'end'` pushed the two action
icons (edit + delete) against the right edge where they wrapped onto
two lines on any viewport narrower than very wide — inconsistent AND
not usable.

## Fix
Apply a single shared config to the actions column on all three
ListViews:
- width: '100px' → '120px' (room for the two icons side by side)
- align: 'end' → 'center' (header and buttons centered in the column)

The three ListViews now share an identical actions column config.

## Tested
Visual check with the three pages side by side:
- Identical column width
- edit + delete icons on a single horizontal line, centered
- Consistent row height, no vertical drift
- No regression on other columns or on edit/delete clicks

## Files
3 files, +3/-3 — User/Group/CompanyListView.vue.