### PR TITLE
feat(delegate): highlight name in delete confirmations (closes #37)

### DIFF
--- a/ui/src/i18n/en.js
+++ b/ui/src/i18n/en.js
@@ -38,6 +38,11 @@ export default {
   'delegate.write': 'Write',
   'delegate.adminHelp': 'With the administration security level on this resource, the receivers of this delegation can create other delegations to share this access with other valid receivers',
   'delegate.writeHelp': 'With the write security level, the receivers of this delegation can modify the members of the involved groups. Without this access, this delegation grants read-only rights',
+  // Fragments wrapping the receiver name in bold red on the delete
+  // confirmation (issue #37). The host keeps the monolithic
+  // `delegate.deleteConfirm` key intact.
+  'delegate.deleteConfirmBefore': 'Are you sure you want to delete the delegation for ',
+  'delegate.deleteConfirmAfter': '?',
   'user.deleteConfirmBefore': 'Are you sure you want to delete ',
   'user.deleteConfirmAfter': '?',
   'group.deleteConfirmBefore': 'Are you sure you want to delete ',

--- a/ui/src/i18n/fr.js
+++ b/ui/src/i18n/fr.js
@@ -31,6 +31,11 @@ export default {
   'delegate.write': 'Écriture',
   'delegate.adminHelp': 'Avec le niveau de sécurité d\'administration sur cette ressource, les receveurs de cette délégation peuvent créer d\'autres délégations pour partager cet accès avec d\'autres receveurs valides',
   'delegate.writeHelp': 'Avec le niveau de sécurité d\'écriture, les receveurs de cette délégation peuvent modifier les membres des groupes impliqués. Sans cet accès cette délégation ne donne qu\'un droit de lecture',
+  // Fragments encadrant le nom du destinataire en gras-rouge dans la
+  // confirmation de suppression (issue #37). Le host garde la clé
+  // monolithique `delegate.deleteConfirm` intacte.
+  'delegate.deleteConfirmBefore': 'Êtes-vous certain de supprimer la délégation pour ',
+  'delegate.deleteConfirmAfter': ' ?',
   'user.deleteConfirmBefore': 'Êtes-vous certain de supprimer ',
   'user.deleteConfirmAfter': ' ?',
   'group.deleteConfirmBefore': 'Êtes-vous certain de supprimer ',

--- a/ui/src/views/DelegateEditDialog.vue
+++ b/ui/src/views/DelegateEditDialog.vue
@@ -103,8 +103,16 @@
       </v-card>
     </v-dialog>
 
-    <LigojConfirmDialog v-model="confirmDelete" :title="t('delegate.deleteTitle')" :message="t('delegate.deleteConfirm', { name: form.receiver })" :confirm-label="t('common.delete')"
-      confirm-color="error" :loading="deleting" @confirm="remove" />
+    <!-- Receiver name rendered in bold red via the LigojConfirmDialog
+         default slot, mirroring the User/Group/Company/GroupMembers
+         confirmation pattern. The host's monolithic
+         `delegate.deleteConfirm` key stays intact for any other
+         consumer; we just use two plugin-local fragments around the
+         name. -->
+    <LigojConfirmDialog v-model="confirmDelete" :title="t('delegate.deleteTitle')" :confirm-label="t('common.delete')"
+      confirm-color="error" :loading="deleting" @confirm="remove">
+      {{ t('delegate.deleteConfirmBefore') }}<strong class="text-error">{{ form.receiver }}</strong>{{ t('delegate.deleteConfirmAfter') }}
+    </LigojConfirmDialog>
 
     <!-- Unsaved-changes guard. Triggered either by a dialog close request
          (Cancel / Esc / scrim) or by useFormGuard's onBeforeRouteLeave

--- a/ui/src/views/DelegateListView.vue
+++ b/ui/src/views/DelegateListView.vue
@@ -67,19 +67,20 @@
       {{ t('delegate.empty') }}
     </v-alert>
 
-    <v-dialog v-model="deleteDialog" max-width="400">
-      <v-card>
-        <v-card-title>{{ t('delegate.deleteTitle') }}</v-card-title>
-        <v-card-text>
-          {{ t('delegate.deleteConfirm', { name: deleteTarget?.receiver?.name || deleteTarget?.name || deleteTarget?.id }) }}
-        </v-card-text>
-        <v-card-actions>
-          <v-spacer />
-          <v-btn variant="text" @click="deleteDialog = false">{{ t('common.cancel') }}</v-btn>
-          <v-btn color="error" variant="elevated" :loading="deleting" @click="confirmDelete">{{ t('common.delete') }}</v-btn>
-        </v-card-actions>
-      </v-card>
-    </v-dialog>
+    <!-- Receiver name rendered in bold red via the LigojConfirmDialog
+         default slot (issue #37), matching the pattern of PR #39
+         for User / Company / Group / GroupMembers and the in-popup
+         delete confirmation of DelegateEditDialog. -->
+    <LigojConfirmDialog
+      v-model="deleteDialog"
+      :title="t('delegate.deleteTitle')"
+      :confirm-label="t('common.delete')"
+      confirm-color="error"
+      :loading="deleting"
+      @confirm="confirmDelete"
+    >
+      {{ t('delegate.deleteConfirmBefore') }}<strong class="text-error">{{ deleteTarget?.receiver?.name || deleteTarget?.name || deleteTarget?.id }}</strong>{{ t('delegate.deleteConfirmAfter') }}
+    </LigojConfirmDialog>
 
     <v-dialog v-model="bulkDeleteDialog" max-width="400">
       <v-card>
@@ -100,7 +101,7 @@
 
 <script setup>
 import { ref, computed, onMounted } from 'vue'
-import { useDataTable, useApi, useAppStore, useI18nStore, LigojDataTableServer } from '@ligoj/host'
+import { useDataTable, useApi, useAppStore, useI18nStore, LigojDataTableServer, LigojConfirmDialog } from '@ligoj/host'
 import DelegateEditDialog from './DelegateEditDialog.vue'
 import { TYPE_ICONS } from '../composables/delegateTypes.js'
 


### PR DESCRIPTION
## Contexte

Issue **#37** — sur l'écran Délégué, les deux dialogs de suppression affichaient le nom du destinataire en texte normal, alors que toutes les autres confirmations sensibles (User / Company / Group / GroupMembers, livrées par PR #39) le rendent en gras+rouge.

Mini-commit volontairement séparé de PR #39 : les fichiers `DelegateEditDialog.vue` / `DelegateListView.vue` (créés par PR #35) n'existaient pas encore sur `feature/vuejs` au moment du travail sur PR #39.

## Changements

### Vues
- **`DelegateListView.vue`** : la dialog ouverte par l'icône 🗑️ de chaque ligne était un `<v-dialog>` inline avec `:message=t('delegate.deleteConfirm', { name })`. Convertie en `LigojConfirmDialog` avec slot par défaut + `<strong class="text-error">{{ name }}</strong>`. Ajout de l'import `LigojConfirmDialog` depuis `@ligoj/host`.
- **`DelegateEditDialog.vue`** : la dialog ouverte par le bouton "Supprimer" intra-popup utilisait déjà `LigojConfirmDialog` mais via la prop `:message=`. Bascule sur le slot par défaut.

### i18n (plugin-id, FR + EN)
- Nouveau : `delegate.deleteConfirmBefore` / `delegate.deleteConfirmAfter` — fragments encadrant le nom du destinataire.
- Textes alignés sur la formulation du host (`"...la délégation pour {name} ?"` → splitté avant/après le nom).
- **La clé monolithique du host `delegate.deleteConfirm` n'est pas touchée** (out of scope) — elle reste disponible pour tout autre consumer.

## Out of scope

- `LigojConfirmDialog` côté core : pas modifié, on utilise son slot par défaut existant.
- `bulkDeleteDialog` de `DelegateListView` (action collective sans nom à exhiber) : laissé tel quel — cohérent avec le choix fait pour le bulk delete des Users (PR #39).

## Test plan

- [x] `npm run build` → 28 modules, 117 kB JS
- [x] `vitest run` → 14/14
- [x] `mvn install -DskipTests` → BUILD SUCCESS
- [x] Smoke test UI :
  - Icône 🗑️ depuis la liste des Délégués → nom du destinataire en gras+rouge
  - Bouton "Supprimer" depuis la popup d'édition → nom du destinataire en gras+rouge

Closes #37