### PR TITLE
fix(ui): widen container-scope actions column and add tab icons

### DIFF
--- a/ui/src/views/ContainerScopeView.vue
+++ b/ui/src/views/ContainerScopeView.vue
@@ -6,8 +6,8 @@
     </div>
 
     <v-tabs v-model="activeTab" class="mb-4">
-      <v-tab value="group">{{ t('nav.groups') }}</v-tab>
-      <v-tab value="company">{{ t('nav.companies') }}</v-tab>
+      <v-tab value="group" prepend-icon="mdi-account-group">{{ t('nav.groups') }}</v-tab>
+      <v-tab value="company" prepend-icon="mdi-domain">{{ t('nav.companies') }}</v-tab>
     </v-tabs>
 
     <v-alert v-if="error" type="warning" variant="tonal" class="mb-4">
@@ -96,7 +96,7 @@ const demoMode = ref(false)
 const headers = computed(() => [
   { title: t('common.name'), key: 'name', sortable: true },
   { title: t('common.status'), key: 'locked', sortable: false, width: '80px' },
-  { title: '', key: 'actions', sortable: false, width: '100px', align: 'end' },
+  { title: '', key: 'actions', sortable: false, width: '120px', align: 'end' },
 ])
 
 const formRef = ref(null)


### PR DESCRIPTION
## Context

Two quick UX fixes on the container-scope view:
- The actions column was too narrow (100px), causing the edit and delete icons to wrap onto two lines.
- The Groups and Entities tabs had no icons, inconsistent with the rest of the identity module where type icons (mdi-account-group, mdi-domain) are used.

## Fix

- Bumps the actions column width from 100px to 120px, matching the other ListViews.
- Adds prepend-icon to the two tabs: mdi-account-group for Groups, mdi-domain for Entities.

## Test plan

- npm run build : OK
- npx vitest run : OK
- Smoke test on Identité → Portées de conteneurs: icons next to tab labels, edit/delete icons on a single row.

Closes #43
Closes #45