### PR TITLE
feat(ui): show DN column in container-scope view

### DIFF
--- a/ui/src/i18n/en.js
+++ b/ui/src/i18n/en.js
@@ -94,4 +94,8 @@ export default {
   'id.group.removeConfirmAfter': ' from group {group}?',
   'id.group.removedToast': 'Removed {user} from {group}',
   'id.group.transitive': 'Indirect member through a sub-group — manage them on the parent.',
+  // LDAP DN exposed in the container-scope view (issue #44). The other
+  // `containerScope.*` keys live in the host; this one is contributed by
+  // the plugin and merged into the i18n store at install time.
+  'containerScope.dn': 'LDAP path',
 }

--- a/ui/src/i18n/fr.js
+++ b/ui/src/i18n/fr.js
@@ -86,4 +86,8 @@ export default {
   'id.group.removeConfirmAfter': ' du groupe {group} ?',
   'id.group.removedToast': '{user} retiré de {group}',
   'id.group.transitive': 'Membre indirect via un sous-groupe — à gérer depuis le groupe parent.',
+  // DN LDAP exposé dans la vue des portées de conteneurs (issue #44).
+  // Les autres clés `containerScope.*` vivent dans le host ; celle-ci est
+  // contribuée par le plugin et mergée au store i18n à l'install.
+  'containerScope.dn': 'Chemin LDAP',
 }

--- a/ui/src/views/ContainerScopeView.vue
+++ b/ui/src/views/ContainerScopeView.vue
@@ -41,6 +41,7 @@
         <v-card-text>
           <v-form ref="formRef" @submit.prevent="save">
             <v-text-field v-model="editForm.name" :label="t('common.name')" :rules="[rules.required]" variant="outlined" class="mb-2" />
+            <v-text-field v-if="editTarget?.id" v-model="editForm.dn" :label="t('containerScope.dn')" variant="outlined" class="mb-2" disabled />
           </v-form>
         </v-card-text>
         <v-card-actions>
@@ -78,13 +79,13 @@ const t = i18n.t
 const activeTab = ref('group')
 
 const DEMO_GROUP_SCOPES = [
-  { id: 1, name: 'Department', locked: false },
-  { id: 2, name: 'Team', locked: false },
-  { id: 3, name: 'Project', locked: true },
+  { id: 1, name: 'Department', dn: 'ou=Department,dc=demo,dc=com', locked: false },
+  { id: 2, name: 'Team', dn: 'ou=Team,dc=demo,dc=com', locked: false },
+  { id: 3, name: 'Project', dn: 'ou=Project,dc=demo,dc=com', locked: true },
 ]
 const DEMO_COMPANY_SCOPES = [
-  { id: 1, name: 'Organization', locked: false },
-  { id: 2, name: 'Business Unit', locked: true },
+  { id: 1, name: 'Organization', dn: 'ou=Organization,dc=demo,dc=com', locked: false },
+  { id: 2, name: 'Business Unit', dn: 'ou=BusinessUnit,dc=demo,dc=com', locked: true },
 ]
 
 const items = ref([])
@@ -95,6 +96,7 @@ const demoMode = ref(false)
 
 const headers = computed(() => [
   { title: t('common.name'), key: 'name', sortable: true },
+  { title: t('containerScope.dn'), key: 'dn', sortable: true },
   { title: t('common.status'), key: 'locked', sortable: false, width: '80px' },
   { title: '', key: 'actions', sortable: false, width: '100px', align: 'end' },
 ])
@@ -140,13 +142,13 @@ watch(activeTab, () => {
 
 function openNew() {
   editTarget.value = null
-  editForm.value = { name: '' }
+  editForm.value = { name: '', dn: '' }
   editDialog.value = true
 }
 
 function openEdit(item) {
   editTarget.value = item
-  editForm.value = { name: item.name }
+  editForm.value = { name: item.name, dn: item.dn || '' }
   editDialog.value = true
 }
 


### PR DESCRIPTION
## Context

Issue #44 lists four fields the original AngularJS view exposed: name, type, dn, locked. In the current Vue view, name is already a column, locked is rendered as a lock icon in the Status column, and type is implicit through the Groups/Companies tabs. The remaining gap is the LDAP DN.

## Fix

- Adds a new sortable column `dn` between Name and Status in the container-scope datatable.
- Adds a read-only DN text field in the edit dialog, shown only when editing an existing scope (the DN is auto-generated by the backend on creation).
- Adds the demo DN values for consistency in demo mode.
- New i18n key `containerScope.dn` (Chemin LDAP / LDAP path), contributed by the plugin and merged into the host i18n store at install.

The save payload is intentionally unchanged: the DN stays a backend concern.

## Test plan

- npm run build : OK
- npx vitest run : OK
- Smoke test on Identité → Portées de conteneurs: DN column visible on both tabs, DN read-only in the edit dialog of an existing scope.

Closes #44