### PR TITLE
feat(ui): move New Scope button into the tab selector

### DIFF
--- a/ui/src/views/ContainerScopeView.vue
+++ b/ui/src/views/ContainerScopeView.vue
@@ -1,13 +1,10 @@
 <template>
   <div>
-    <div class="d-flex flex-wrap align-center mb-4 ga-2">
-      <v-spacer />
-      <v-btn color="primary" prepend-icon="mdi-plus" @click="openNew">{{ t('containerScope.new') }}</v-btn>
-    </div>
-
     <v-tabs v-model="activeTab" class="mb-4">
       <v-tab value="group" prepend-icon="mdi-account-group">{{ t('nav.groups') }}</v-tab>
       <v-tab value="company" prepend-icon="mdi-domain">{{ t('nav.companies') }}</v-tab>
+      <v-spacer />
+      <v-btn color="primary" prepend-icon="mdi-plus" @click="openNew" class="mr-2 align-self-center">{{ t('containerScope.new') }}</v-btn>
     </v-tabs>
 
     <v-alert v-if="error" type="warning" variant="tonal" class="mb-4">


### PR DESCRIPTION
## Context

Issue #49 asks for the New Scope button to be moved from its dedicated row above the tabs into the tab selector itself, right-aligned, so the action sits on the same line as the Groups and Companies tabs.

## Fix

- Removes the standalone row that previously hosted the button.
- Adds a v-spacer + button inside the v-tabs, after the two v-tab entries.

No behavior change beyond the layout.

## Test plan

- npm run build : OK
- npx vitest run : OK (14 tests)
- Smoke test on Identité -> Portées de conteneurs: New Scope button visible at the right of the tab strip, on the same row as Groups and Companies.

Closes #49