### PR TITLE
feat(ui): add entity icons to dialog titles

### DIFF
--- a/ui/src/components/CompanyEditPanel.vue
+++ b/ui/src/components/CompanyEditPanel.vue
@@ -99,6 +99,7 @@
     <LigojConfirmDialog
       v-model="confirmDelete"
       :title="t('company.deleteTitle')"
+      :icon="TYPE_ICONS.COMPANY"
       :confirm-label="t('common.delete')"
       confirm-color="error"
       :loading="deleting"
@@ -112,6 +113,7 @@
 <script setup>
 import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
 import { useApi, useErrorStore, useI18nStore, LigojConfirmDialog } from '@ligoj/host'
+import { TYPE_ICONS } from '../composables/delegateTypes.js'
 
 const props = defineProps({
   /**

--- a/ui/src/components/GroupEditPanel.vue
+++ b/ui/src/components/GroupEditPanel.vue
@@ -75,6 +75,7 @@
     <LigojConfirmDialog
       v-model="confirmDelete"
       :title="t('group.deleteTitle')"
+      :icon="TYPE_ICONS.GROUP"
       :confirm-label="t('common.delete')"
       confirm-color="error"
       :loading="deleting"
@@ -88,6 +89,7 @@
 <script setup>
 import { ref, computed, onMounted } from 'vue'
 import { useApi, useErrorStore, useI18nStore, LigojConfirmDialog } from '@ligoj/host'
+import { TYPE_ICONS } from '../composables/delegateTypes.js'
 
 const props = defineProps({
   /**

--- a/ui/src/components/GroupMembersPanel.vue
+++ b/ui/src/components/GroupMembersPanel.vue
@@ -81,7 +81,7 @@
     <!-- Confirm dialog. Vuetify teleports it to <body>, so being
          nested inside this panel — which itself can be inside a
          <v-dialog> — doesn't cause z-index issues. -->
-    <LigojConfirmDialog v-model="removeDialog" :title="t('id.group.removeTitle')" :confirm-label="t('common.remove')" confirm-color="error" :loading="removing" @confirm="confirmRemove">
+    <LigojConfirmDialog v-model="removeDialog" :title="t('id.group.removeTitle')" :icon="TYPE_ICONS.USER" :confirm-label="t('common.remove')" confirm-color="error" :loading="removing" @confirm="confirmRemove">
       {{ t('id.group.removeConfirmBefore') }}<strong class="text-error">{{ removeTarget?.id }}</strong>{{ t('id.group.removeConfirmAfter', { group: groupName }) }}
     </LigojConfirmDialog>
   </div>
@@ -97,6 +97,7 @@ import {
   LigojDataTableServer,
   LigojConfirmDialog,
 } from '@ligoj/host'
+import { TYPE_ICONS } from '../composables/delegateTypes.js'
 
 const props = defineProps({
   /**

--- a/ui/src/composables/delegateTypes.js
+++ b/ui/src/composables/delegateTypes.js
@@ -18,6 +18,12 @@ export const TYPE_ICONS = {
   GROUP: 'mdi-account-group',
   COMPANY: 'mdi-domain',
   TREE: 'mdi-file-tree',
+  // Entity icons reused for dialog titles (issue #51): the container-scope
+  // view and delegations have no delegation-enum entry but still need a
+  // representative icon. SCOPE matches the file-tree-outline used in the
+  // container-scope datatable header.
+  SCOPE: 'mdi-file-tree-outline',
+  DELEGATE: 'mdi-shield-account-outline',
 }
 
 // Receivers cannot be a TREE — only USER / GROUP / COMPANY can hold a

--- a/ui/src/views/CompanyListView.vue
+++ b/ui/src/views/CompanyListView.vue
@@ -95,7 +95,10 @@
 
     <v-dialog v-model="deleteDialog" max-width="400">
       <v-card>
-        <v-card-title>{{ t('company.deleteTitle') }}</v-card-title>
+        <v-card-title class="d-flex align-center ga-2">
+          <v-icon color="primary">{{ TYPE_ICONS.COMPANY }}</v-icon>
+          <span>{{ t('company.deleteTitle') }}</span>
+        </v-card-title>
         <v-card-text>
           {{ t('company.deleteConfirmBefore') }}<strong class="text-error">{{ deleteTarget?.name }}</strong>{{ t('company.deleteConfirmAfter') }}
         </v-card-text>
@@ -109,7 +112,10 @@
 
     <v-dialog v-model="bulkDeleteDialog" max-width="400">
       <v-card>
-        <v-card-title>{{ t('common.bulkDeleteTitle') }}</v-card-title>
+        <v-card-title class="d-flex align-center ga-2">
+          <v-icon color="primary">{{ TYPE_ICONS.COMPANY }}</v-icon>
+          <span>{{ t('common.bulkDeleteTitle') }}</span>
+        </v-card-title>
         <v-card-text>{{ t('common.bulkDeleteConfirm', { count: selected.length }) }}</v-card-text>
         <v-card-actions>
           <v-spacer />
@@ -125,6 +131,7 @@
 import { ref, computed, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useDataTable, useApi, useAppStore, useErrorStore, useI18nStore, LigojDataTableServer } from '@ligoj/host'
+import { TYPE_ICONS } from '../composables/delegateTypes.js'
 import CompanyEditPanel from '../components/CompanyEditPanel.vue'
 
 const router = useRouter()

--- a/ui/src/views/ContainerScopeView.vue
+++ b/ui/src/views/ContainerScopeView.vue
@@ -42,7 +42,10 @@
 
     <v-dialog v-model="editDialog" max-width="500">
       <v-card>
-        <v-card-title>{{ editTarget?.id ? t('containerScope.edit') : t('containerScope.new') }}</v-card-title>
+        <v-card-title class="d-flex align-center ga-2">
+          <v-icon color="primary">{{ TYPE_ICONS.SCOPE }}</v-icon>
+          <span>{{ editTarget?.id ? t('containerScope.edit') : t('containerScope.new') }}</span>
+        </v-card-title>
         <v-card-text>
           <v-form ref="formRef" @submit.prevent="save">
             <v-text-field v-model="editForm.name" :label="t('common.name')" :rules="[rules.required]" variant="outlined" class="mb-2" />
@@ -59,7 +62,10 @@
 
     <v-dialog v-model="deleteDialog" max-width="400">
       <v-card>
-        <v-card-title>{{ t('containerScope.deleteTitle') }}</v-card-title>
+        <v-card-title class="d-flex align-center ga-2">
+          <v-icon color="primary">{{ TYPE_ICONS.SCOPE }}</v-icon>
+          <span>{{ t('containerScope.deleteTitle') }}</span>
+        </v-card-title>
         <v-card-text>{{ t('containerScope.deleteConfirm', { name: deleteTarget?.name }) }}</v-card-text>
         <v-card-actions>
           <v-spacer />
@@ -74,6 +80,7 @@
 <script setup>
 import { ref, computed, watch, onMounted } from 'vue'
 import { useApi, useAppStore, useErrorStore, useI18nStore, LigojDataTable } from '@ligoj/host'
+import { TYPE_ICONS } from '../composables/delegateTypes.js'
 
 const api = useApi()
 const appStore = useAppStore()

--- a/ui/src/views/DelegateEditDialog.vue
+++ b/ui/src/views/DelegateEditDialog.vue
@@ -8,7 +8,10 @@
          pattern as UserEditDialog. -->
     <v-dialog :model-value="modelValue" @update:model-value="onDialogModel" max-width="700" scrollable>
       <v-card>
-        <v-card-title>{{ isEdit ? t('delegate.edit') : t('delegate.new') }}</v-card-title>
+        <v-card-title class="d-flex align-center ga-2">
+          <v-icon color="primary">{{ TYPE_ICONS.DELEGATE }}</v-icon>
+          <span>{{ isEdit ? t('delegate.edit') : t('delegate.new') }}</span>
+        </v-card-title>
 
         <v-card-text>
           <v-skeleton-loader v-if="loading" type="article" />
@@ -109,7 +112,7 @@
          `delegate.deleteConfirm` key stays intact for any other
          consumer; we just use two plugin-local fragments around the
          name. -->
-    <LigojConfirmDialog v-model="confirmDelete" :title="t('delegate.deleteTitle')" :confirm-label="t('common.delete')"
+    <LigojConfirmDialog v-model="confirmDelete" :title="t('delegate.deleteTitle')" :icon="TYPE_ICONS.DELEGATE" :confirm-label="t('common.delete')"
       confirm-color="error" :loading="deleting" @confirm="remove">
       {{ t('delegate.deleteConfirmBefore') }}<strong class="text-error">{{ form.receiver }}</strong>{{ t('delegate.deleteConfirmAfter') }}
     </LigojConfirmDialog>
@@ -119,7 +122,7 @@
          when navigating away from the list with the dialog still open.
          persistent: only the explicit buttons dismiss it, so pendingClose
          is always reset through onGuardConfirm/onGuardCancel. -->
-    <LigojConfirmDialog v-model="showGuardDialog" :title="t('common.unsavedTitle')" :message="t('common.unsavedMsg')" :confirm-label="t('common.discard')" confirm-color="warning"
+    <LigojConfirmDialog v-model="showGuardDialog" :title="t('common.unsavedTitle')" icon="mdi-content-save-alert" icon-color="warning" :message="t('common.unsavedMsg')" :confirm-label="t('common.discard')" confirm-color="warning"
       persistent @confirm="onGuardConfirm" @cancel="onGuardCancel" />
   </div>
 </template>

--- a/ui/src/views/DelegateListView.vue
+++ b/ui/src/views/DelegateListView.vue
@@ -97,6 +97,7 @@
     <LigojConfirmDialog
       v-model="deleteDialog"
       :title="t('delegate.deleteTitle')"
+      :icon="TYPE_ICONS.DELEGATE"
       :confirm-label="t('common.delete')"
       confirm-color="error"
       :loading="deleting"
@@ -107,7 +108,10 @@
 
     <v-dialog v-model="bulkDeleteDialog" max-width="400">
       <v-card>
-        <v-card-title>{{ t('common.bulkDeleteTitle') }}</v-card-title>
+        <v-card-title class="d-flex align-center ga-2">
+          <v-icon color="primary">{{ TYPE_ICONS.DELEGATE }}</v-icon>
+          <span>{{ t('common.bulkDeleteTitle') }}</span>
+        </v-card-title>
         <v-card-text>{{ t('common.bulkDeleteConfirm', { count: selected.length }) }}</v-card-text>
         <v-card-actions>
           <v-spacer />

--- a/ui/src/views/GroupListView.vue
+++ b/ui/src/views/GroupListView.vue
@@ -108,7 +108,10 @@
 
     <v-dialog v-model="deleteDialog" max-width="400">
       <v-card>
-        <v-card-title>{{ t('group.deleteTitle') }}</v-card-title>
+        <v-card-title class="d-flex align-center ga-2">
+          <v-icon color="primary">{{ TYPE_ICONS.GROUP }}</v-icon>
+          <span>{{ t('group.deleteTitle') }}</span>
+        </v-card-title>
         <v-card-text>
           {{ t('group.deleteConfirmBefore') }}<strong class="text-error">{{ deleteTarget?.name }}</strong>{{ t('group.deleteConfirmAfter') }}
         </v-card-text>
@@ -122,7 +125,10 @@
 
     <v-dialog v-model="bulkDeleteDialog" max-width="400">
       <v-card>
-        <v-card-title>{{ t('common.bulkDeleteTitle') }}</v-card-title>
+        <v-card-title class="d-flex align-center ga-2">
+          <v-icon color="primary">{{ TYPE_ICONS.GROUP }}</v-icon>
+          <span>{{ t('common.bulkDeleteTitle') }}</span>
+        </v-card-title>
         <v-card-text>{{ t('common.bulkDeleteConfirm', { count: selected.length }) }}</v-card-text>
         <v-card-actions>
           <v-spacer />
@@ -138,6 +144,7 @@
 import { ref, computed, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useDataTable, useApi, useAppStore, useErrorStore, useI18nStore, LigojDataTableServer } from '@ligoj/host'
+import { TYPE_ICONS } from '../composables/delegateTypes.js'
 import { useGroupMembersDialog } from '../composables/useGroupMembersDialog.js'
 import GroupEditPanel from '../components/GroupEditPanel.vue'
 

--- a/ui/src/views/UserEditDialog.vue
+++ b/ui/src/views/UserEditDialog.vue
@@ -13,6 +13,7 @@
              details and group-members dialogs. Sourced from the prop
              — `form.id` would lag until the load completes. -->
         <v-card-title class="d-flex align-center ga-2">
+          <v-icon color="primary">{{ TYPE_ICONS.USER }}</v-icon>
           <span>{{ isEdit ? t('user.edit') : t('user.new') }}</span>
           <span v-if="isEdit" class="text-primary">{{ userId }}</span>
         </v-card-title>
@@ -113,7 +114,7 @@
       </v-card>
     </v-dialog>
 
-    <LigojConfirmDialog v-model="confirmDelete" :title="t('user.deleteTitle')" :confirm-label="t('common.delete')" confirm-color="error" :loading="deleting" @confirm="remove">
+    <LigojConfirmDialog v-model="confirmDelete" :title="t('user.deleteTitle')" :icon="TYPE_ICONS.USER" :confirm-label="t('common.delete')" confirm-color="error" :loading="deleting" @confirm="remove">
       {{ t('user.deleteConfirmBefore') }}<strong class="text-error">{{ form.id }}</strong>{{ t('user.deleteConfirmAfter') }}
     </LigojConfirmDialog>
 
@@ -122,7 +123,7 @@
          navigating away from the list with the dialog still open.
          persistent: only the explicit buttons dismiss it, so pendingClose
          is always reset through onGuardConfirm/onGuardCancel. -->
-    <LigojConfirmDialog v-model="showGuardDialog" :title="t('common.unsavedTitle')" :message="t('common.unsavedMsg')" :confirm-label="t('common.discard')" confirm-color="warning" persistent
+    <LigojConfirmDialog v-model="showGuardDialog" :title="t('common.unsavedTitle')" icon="mdi-content-save-alert" icon-color="warning" :message="t('common.unsavedMsg')" :confirm-label="t('common.discard')" confirm-color="warning" persistent
       @confirm="onGuardConfirm" @cancel="onGuardCancel" />
 
     <!-- Chantier D2 (rattrapage): mirror the UserListView pattern so the
@@ -130,7 +131,7 @@
          `user.<action>Confirm` message with {id} interpolation kept the
          name as plain text, which felt visually weaker than the same
          action triggered from the list row. -->
-    <LigojConfirmDialog v-model="actionDialog" :title="t('user.' + actionType)" :loading="actionLoading" @confirm="confirmAction">
+    <LigojConfirmDialog v-model="actionDialog" :title="t('user.' + actionType)" :icon="TYPE_ICONS.USER" :loading="actionLoading" @confirm="confirmAction">
       {{ t('user.' + actionType + 'ConfirmBefore') }}<strong class="text-error">{{ form.id }}</strong>{{ t('user.' + actionType + 'ConfirmAfter') }}
     </LigojConfirmDialog>
   </div>
@@ -139,6 +140,7 @@
 <script setup>
 import { ref, computed, watch } from 'vue'
 import { useApi, useFormGuard, useErrorStore, useI18nStore, LigojConfirmDialog } from '@ligoj/host'
+import { TYPE_ICONS } from '../composables/delegateTypes.js'
 
 const props = defineProps({
   // Dialog visibility (v-model).

--- a/ui/src/views/UserListView.vue
+++ b/ui/src/views/UserListView.vue
@@ -120,7 +120,7 @@
 
     <!-- Single-user delete (chantier D2): name in bold red via the
          default slot of LigojConfirmDialog. -->
-    <LigojConfirmDialog v-model="deleteDialog" :title="t('user.deleteTitle')" :confirm-label="t('common.delete')" confirm-color="error" :loading="deleting" @confirm="confirmDeleteUser">
+    <LigojConfirmDialog v-model="deleteDialog" :title="t('user.deleteTitle')" :icon="TYPE_ICONS.USER" :confirm-label="t('common.delete')" confirm-color="error" :loading="deleting" @confirm="confirmDeleteUser">
       {{ t('user.deleteConfirmBefore') }}<strong class="text-error">{{ deleteTarget?.id }}</strong>{{ t('user.deleteConfirmAfter') }}
     </LigojConfirmDialog>
 
@@ -129,7 +129,7 @@
          as a sensitive single-item confirmation. The host's monolithic
          `common.bulkDeleteConfirm` key stays intact; we just use two
          new plugin-local fragments around the count. -->
-    <LigojConfirmDialog v-model="bulkDeleteDialog" :title="t('common.bulkDeleteTitle')" :confirm-label="t('common.delete')" confirm-color="error" :loading="deleting" @confirm="confirmBulkDelete">
+    <LigojConfirmDialog v-model="bulkDeleteDialog" :title="t('common.bulkDeleteTitle')" :icon="TYPE_ICONS.USER" :confirm-label="t('common.delete')" confirm-color="error" :loading="deleting" @confirm="confirmBulkDelete">
       {{ t('common.bulkDeleteConfirmBefore') }}<strong class="text-error">{{ selected.length }}</strong>{{ t('common.bulkDeleteConfirmAfter') }}
     </LigojConfirmDialog>
 
@@ -137,7 +137,7 @@
          triggered from the row gear menu (chantier D2): the login is
          now bolded and coloured via two i18n fragments around it
          (user.<action>ConfirmBefore / user.<action>ConfirmAfter). -->
-    <LigojConfirmDialog v-model="actionDialog" :title="t('user.' + actionType)" :confirm-label="t('common.confirm')" :loading="actionLoading" @confirm="confirmUserAction">
+    <LigojConfirmDialog v-model="actionDialog" :title="t('user.' + actionType)" :icon="TYPE_ICONS.USER" :confirm-label="t('common.confirm')" :loading="actionLoading" @confirm="confirmUserAction">
       {{ t('user.' + actionType + 'ConfirmBefore') }}<strong class="text-error">{{ actionTarget?.id }}</strong>{{ t('user.' + actionType + 'ConfirmAfter') }}
     </LigojConfirmDialog>
 
@@ -149,6 +149,7 @@
 <script setup>
 import { ref, computed, onMounted } from 'vue'
 import { useDataTable, useApi, useAppStore, useErrorStore, useI18nStore, ImportExportBar, LigojDataTableServer, LigojConfirmDialog } from '@ligoj/host'
+import { TYPE_ICONS } from '../composables/delegateTypes.js'
 import UserEditDialog from './UserEditDialog.vue'
 
 const appStore = useAppStore()


### PR DESCRIPTION
## Context

Issue #51 asks to prepend every dialog title with an icon representing the edited entity, and to generalize the concept across the application. Some dialogs (group/company details, group members) already followed this pattern; this PR brings the rest in line.

## Change

- Raw `v-dialog` titles (container-scope edit/delete, group/company/delegate delete and bulk-delete confirmations, delegate edit) get a leading `v-icon`.
- `LigojConfirmDialog` call sites pass the new `:icon` prop (user delete/bulk/action, group/company/member removal, delegate delete).
- Unsaved-changes guards use a `mdi-content-save-alert` icon.
- Icons reuse the shared `TYPE_ICONS` map, extended with `SCOPE` and `DELEGATE`.

## Dependency

The `LigojConfirmDialog` `:icon` prop is added in ligoj/ligoj#104. Unknown attributes fall through harmlessly until that lands, so this PR is safe to merge independently, but the confirm-dialog icons only render once #104 is deployed.

## Test plan

- npm run build : OK
- npx vitest run : OK (14 tests)
- mvn install -DskipTests : OK

Closes #51