### PR TITLE
fix(ui): add tooltips on solo icons in tables

### DIFF
--- a/ui/src/i18n/en.js
+++ b/ui/src/i18n/en.js
@@ -39,7 +39,9 @@ export default {
   'delegate.adminHelp': 'With the administration security level on this resource, the receivers of this delegation can create other delegations to share this access with other valid receivers',
   'delegate.writeHelp': 'With the write security level, the receivers of this delegation can modify the members of the involved groups. Without this access, this delegation grants read-only rights',
   'delegate.adminGranted': 'Administration granted',
+  'delegate.adminNotGranted': 'Administration not granted',
   'delegate.writeGranted': 'Write access granted',
+  'delegate.writeNotGranted': 'Write access not granted',
   // Fragments wrapping the receiver name in bold red on the delete
   // confirmation (issue #37). The host keeps the monolithic
   // `delegate.deleteConfirm` key intact.

--- a/ui/src/i18n/fr.js
+++ b/ui/src/i18n/fr.js
@@ -32,7 +32,9 @@ export default {
   'delegate.adminHelp': 'Avec le niveau de sécurité d\'administration sur cette ressource, les receveurs de cette délégation peuvent créer d\'autres délégations pour partager cet accès avec d\'autres receveurs valides',
   'delegate.writeHelp': 'Avec le niveau de sécurité d\'écriture, les receveurs de cette délégation peuvent modifier les membres des groupes impliqués. Sans cet accès cette délégation ne donne qu\'un droit de lecture',
   'delegate.adminGranted': 'Administration accordée',
+  'delegate.adminNotGranted': 'Administration non accordée',
   'delegate.writeGranted': 'Écriture accordée',
+  'delegate.writeNotGranted': 'Écriture non accordée',
   // Fragments encadrant le nom du destinataire en gras-rouge dans la
   // confirmation de suppression (issue #37). Le host garde la clé
   // monolithique `delegate.deleteConfirm` intacte.

--- a/ui/src/views/DelegateListView.vue
+++ b/ui/src/views/DelegateListView.vue
@@ -43,10 +43,14 @@
         </span>
       </template>
       <template #cell.canAdmin="{ item }">
-        <span class="bdot" :class="{ on: item.canAdmin }" :title="item.canAdmin ? t('delegate.adminGranted') : ''" />
+        <span class="bdot" :class="{ on: item.canAdmin }">
+          <v-tooltip activator="parent" :text="item.canAdmin ? t('delegate.adminGranted') : t('delegate.adminNotGranted')" location="top" />
+        </span>
       </template>
       <template #cell.canWrite="{ item }">
-        <span class="bdot" :class="{ on: item.canWrite }" :title="item.canWrite ? t('delegate.writeGranted') : ''" />
+        <span class="bdot" :class="{ on: item.canWrite }">
+          <v-tooltip activator="parent" :text="item.canWrite ? t('delegate.writeGranted') : t('delegate.writeNotGranted')" location="top" />
+        </span>
       </template>
       <template #actions="{ item }">
         <v-menu location="bottom end">


### PR DESCRIPTION
Adds hover tooltips to the solo status pictos in `DelegateListView` (Administration / Écriture columns). Previously only the *granted* (green) state carried a native `title`; the *not-granted* (grey) state had an empty title and no tooltip — the symptom reported in #54.

## Changes
- `DelegateListView.vue`: both status dots now use `<v-tooltip activator="parent" location="top">` with a conditional label, so all four states (admin/write × granted/not) have a tooltip. Removes the native `:title` in favour of the `activator="parent"` pattern already used in `GroupMembersPanel` / `DelegateEditDialog`.
- i18n: new keys `delegate.adminNotGranted` / `delegate.writeNotGranted` (fr + en); existing `*Granted` keys reused.

## Scope
Audited the other plugin-id tables (`UserListView`, `GroupListView`, `CompanyListView`, `ContainerScopeView`): their solo status icons already expose tooltips (locked state via `<v-tooltip>`, dash otherwise) — no change needed.

## Verification
- `npm run build` ✅, `vitest` 14/14 ✅
- Runtime on `/id/delegate`: dots render (green = granted, grey = not), tooltips correct on all four states including the grey *non accordée* case.

Closes #54.