### PR TITLE
fix(scope): make the DN/LDAP path editable in edition mode

### DIFF
--- a/ui/src/views/ContainerScopeView.vue
+++ b/ui/src/views/ContainerScopeView.vue
@@ -54,7 +54,7 @@
         <LjAvailabilityField v-model="editForm.name" v-model:taken="nameTaken" :endpoint="'service/id/container-scope/' + activeTab" :enabled="!editTarget?.id && !demoMode"
           prepend-inner-icon="mdi-form-textbox" :label="t('common.name')" :disabled="readOnly" class="mb-2" autofocus />
         <v-text-field v-model="editForm.dn" prepend-inner-icon="mdi-file-tree-outline" :label="t('containerScope.dn')" variant="outlined"
-          :disabled="!!editTarget?.id || readOnly" :rules="editTarget?.id ? [] : [rules.required]" />
+          :disabled="readOnly" :rules="[rules.required]" />
         <v-checkbox v-model="editForm.locked" :label="t('containerScope.locked')" :disabled="readOnly" color="primary" density="compact" hide-details />
         <p v-if="editForm.locked" class="locked-note"><v-icon size="14">mdi-alert-outline</v-icon>{{ t('containerScope.lockedHint') }}</p>
       </v-form>


### PR DESCRIPTION
Follow-up to #57. The previous patch kept the DN field read-only when editing an existing container scope.

In the issue comment, Fabrice clarified: "And this path should be editable". So the LDAP path must be editable in **both** create and edit mode, not only at creation.

This change removes the `!!editTarget?.id` part of the field's `disabled` binding (the field stays disabled only in read-only/view mode) and simplifies the validation rules so the path is always required.

The backend already allows updating `ContainerScope.dn` (no `@Immutable` on the field).

Closes #55.